### PR TITLE
test: validate actions-mn/setup with ribose flavor (public)

### DIFF
--- a/.github/workflows/test-setup-flavors.yml
+++ b/.github/workflows/test-setup-flavors.yml
@@ -33,7 +33,7 @@ jobs:
           ruby-version: '3.2'
 
       - name: Setup Metanorma with Ribose flavor
-        uses: actions-mn/setup@feat/add-extra-flavors-support
+        uses: actions-mn/setup@v3
         with:
           installation-method: gem
           extra-flavors: ribose

--- a/.github/workflows/test-setup-flavors.yml
+++ b/.github/workflows/test-setup-flavors.yml
@@ -1,0 +1,46 @@
+# Test workflow for actions-mn/setup with extra flavors
+# This replaces the docker.yml workflow to test the new consolidated setup action
+name: test-setup-with-flavors
+
+on:
+  push:
+    branches: [ test/setup-action-flavors ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Setup Metanorma with Ribose flavor
+        uses: actions-mn/setup@feat/add-extra-flavors-support
+        with:
+          installation-method: gem
+          extra-flavors: ribose
+          # ribose is a public flavor, no token needed
+
+      - name: Metanorma generate site
+        uses: actions-mn/build-and-publish@v1
+        with:
+          agree-to-terms: true
+          destination: artifact


### PR DESCRIPTION
## Purpose

Test the new actions-mn/setup feature that consolidates setup-flavors functionality.

This PR validates that the new extra-flavors input works with **public flavors** (ribose) which do not require GitHub Packages authentication.

## Changes

Added .github/workflows/test-setup-flavors.yml that uses:
- actions-mn/setup@feat/add-extra-flavors-support
- installation-method: gem
- extra-flavors: ribose (public flavor from RubyGems)

## Key Difference from BSI Test

- **ribose** is a public flavor available on RubyGems.org
- No github-packages-token required
- Simpler setup flow for public flavors

## Related

- actions-mn/setup PR #29: https://github.com/actions-mn/setup/pull/29
- mn-samples-bsi PR #358: https://github.com/metanorma/mn-samples-bsi/pull/358 (private flavor test)